### PR TITLE
Support for running shipit headless, and helpful handling of ~

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+    * Add support for not running under a terminal.
+
 0.55 (2010-03-27)
 
 	* Added a bunch of links to http://contributing.appspot.com/shipit

--- a/lib/ShipIt/Step/AddToSVNDir.pm
+++ b/lib/ShipIt/Step/AddToSVNDir.pm
@@ -30,6 +30,7 @@ In .shipit config:
 sub init {
     my ($self, $conf) = @_;
     $self->{dir} = $conf->value("AddToSVNDir.dir");
+    $self->{dir} =~ s/^~/$ENV{HOME}/;
     die "AddToSVNDir.dir not defined in config."     unless $self->{dir};
     die "AddToSVNDir.dir's value isn't a directory." unless -d $self->{dir};
     die "AddToSVNDir.dir's value isn't an svn directory." unless -d "$self->{dir}/.svn";

--- a/lib/ShipIt/Step/FindVersion.pm
+++ b/lib/ShipIt/Step/FindVersion.pm
@@ -18,7 +18,7 @@ sub run {
     # make dist or a test failed or something, so they're re-running it...)
     $def = "[$ver] " unless $is_tagged;
 
-    my $newver = $term->readline("Next/release version? $def");
+    my $newver = $term ? $term->readline("Next/release version? $def") : undef;
     $newver ||= $ver;
 
     # are they just compulsively running shipit?  i.e., they just asked for same

--- a/lib/ShipIt/Util.pm
+++ b/lib/ShipIt/Util.pm
@@ -10,7 +10,12 @@ use File::Temp ();
 use File::Path ();
 use Cwd;
 
-our $term = Term::ReadLine->new("prompt");
+our $term;
+
+# We may not get a terminal if we're running under an automatic build tool.
+eval {
+    Term::ReadLine->new("prompt");
+};
 
 sub slurp {
     my ($file) = @_;
@@ -32,6 +37,7 @@ sub bool_prompt {
     my ($q, $def) = @_;
     $def = uc($def || "");
     die "bogus default" unless $def =~ /^[YN]?$/;
+    return $def if !$term;
     my $opts = " [y/n]";
     $opts = " [Y/n]" if $def eq "Y";
     $opts = " [y/N]" if $def eq "N";


### PR DESCRIPTION
We're running with these two patches here.  The first makes shipit happy to run with no terminal, we use this to do builds under Jenkins. The second make ~ become a shortcut to the user's home directory for apt repository paths.

Kind regards,
Dave Lambley
