### PR TITLE
Set an environment variable in release engineering (releng)

### DIFF
--- a/shipit
+++ b/shipit
@@ -37,6 +37,8 @@ unless (-e CONFFILE) {
         "Re-run with --write-config to get default config in \$EDITOR.\n";
 }
 
+$ENV{IN_RELENG} = 1;
+
 my $conf  = ShipIt::Conf->parse(CONFFILE);
 my $state = ShipIt::State->new($conf);
 $state->set_dry_run($opt_dry);


### PR DESCRIPTION
Sometimes we'd like to test the module to be released in strict-but-slow conditions. This environment allows authors to set such a condition. Can you review the change please?

Thanks,
