### PR TITLE
set TEST_AUTHOR

### DIFF
--- a/lib/ShipIt/ProjectType/Perl/MakeMaker.pm
+++ b/lib/ShipIt/ProjectType/Perl/MakeMaker.pm
@@ -33,7 +33,7 @@ sub disttest {
 
     $self->prepare_build;
     {
-        local $ENV{TEST_AUTHOR} = 1;
+        local $ENV{RELEASE_TESTING} = 1;
         $self->run_build('disttest') or die "Disttest failed";
     }
     $self->run_build('distclean') or die "Distclean failed";

--- a/lib/ShipIt/ProjectType/Perl/MakeMaker.pm
+++ b/lib/ShipIt/ProjectType/Perl/MakeMaker.pm
@@ -32,7 +32,10 @@ sub disttest {
     my $self = shift;
 
     $self->prepare_build;
-    $self->run_build('disttest')  or die "Disttest failed";
+    {
+        local $ENV{TEST_AUTHOR} = 1;
+        $self->run_build('disttest') or die "Disttest failed";
+    }
     $self->run_build('distclean') or die "Distclean failed";
 
     my @missing    = manicheck;


### PR DESCRIPTION
Test::Perl::Critic states as recommended usage for CPAN distribution authors to make the execution of the tests dependent on the existence of a TEST_AUTHOR environment variable - cf https://metacpan.org/module/Test::Perl::Critic#SYNOPSIS

I think it is a good idea to set this variable during the "disttest" step, so that these tests will be executed when shipit is performing the tests.
